### PR TITLE
chore(makefile): rename install task, clarify Docker commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install update format lint run up logs down
+.PHONY: install update format run up logs down
 
 install:
 	python -m pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-.PHONY: init update format run up
+.PHONY: install update format lint run up logs down
 
-init:
-	pip install -r requirements.txt
+install:
+	python -m pip install -r requirements.txt
 
 update:
 	pur -r requirements.txt
@@ -10,7 +10,13 @@ format:
 	ruff format main.py utils
 
 run:
-	python3 main.py
+	python main.py
 
 up:
-	docker compose up --build && docker logs extractor > logs.txt  && docker compose down
+	docker compose up --build
+
+logs:
+	docker logs extractor > logs.txt
+
+down:
+	docker compose down


### PR DESCRIPTION
- Renamed `init` to `install` for clarity
- Split `up` command into `up`, `logs`, and `down` for better control
- Kept `update` and `format` as-is